### PR TITLE
Add support for Python 3.6

### DIFF
--- a/3.6.4/Makefile
+++ b/3.6.4/Makefile
@@ -1,0 +1,78 @@
+PYVERSION=3.6.4
+PYMINOR=$(basename $(PYVERSION))
+
+ROOT=$(abspath ..)
+
+HOSTINSTALL=$(ROOT)/build/$(PYVERSION)/host
+HOSTBUILD=$(HOSTINSTALL)/Python-$(PYVERSION)
+HOSTPYTHON=$(HOSTINSTALL)/bin/python3$(EXE)
+HOSTPGEN=$(HOSTINSTALL)/bin/pgen$(EXE)
+
+BUILD=$(ROOT)/build/$(PYVERSION)/Python-$(PYVERSION)
+INSTALL=$(ROOT)/installs/python-$(PYVERSION)
+TARBALL=$(ROOT)/downloads/Python-$(PYVERSION).tgz
+URL=https://www.python.org/ftp/python/$(PYVERSION)/Python-$(PYVERSION).tgz
+LIB=libpython$(PYMINOR).a
+
+
+all: install
+
+
+install: $(BUILD)/$(LIB)
+	( \
+		cd $(BUILD); \
+		sed -i -e 's/libinstall:.*/libinstall:/' Makefile; \
+		emmake make HOSTPYTHON=$(HOSTPYTHON) PYTHON_FOR_BUILD=$(HOSTPYTHON) CROSS_COMPILE=yes inclinstall libinstall $(LIB) && \
+		cp $(LIB) $(INSTALL)/lib/ && \
+		cp $(HOSTINSTALL)/lib/python$(PYMINOR)/`$(HOSTPYTHON) -c "import sysconfig; print(sysconfig._get_sysconfigdata_name())"`.py $(INSTALL)/lib/python$(PYMINOR)/_sysconfigdata__emscripten_x86_64-linux-gnu.py \
+	)
+
+
+clean:
+	-rm -fr $(HOSTINSTALL)
+	-rm -fr $(BUILD)
+
+
+$(TARBALL):
+	[ -d ../downloads ] || mkdir ../downloads
+	wget -q -O $@ $(URL)
+	md5sum --quiet --check checksums || (rm $@; false)
+
+
+$(HOSTPYTHON) $(HOSTPGEN): $(TARBALL)
+	mkdir -p $(HOSTINSTALL)
+	[ -d $(HOSTBUILD) ] || tar -C $(HOSTINSTALL) -xf $(TARBALL)
+	( \
+		cd $(HOSTBUILD); \
+		./configure --prefix=$(HOSTINSTALL) && \
+	  make regen-grammar && \
+		make install && \
+		cp Parser/pgen$(EXE) $(HOSTINSTALL)/bin/ && \
+		make distclean \
+	)
+
+
+$(BUILD)/.patched: $(TARBALL)
+	[ -d $(BUILD) ] || (mkdir -p $(dir $(BUILD)); tar -C $(dir $(BUILD)) -xf $(TARBALL))
+	cat patches/*.patch | (cd $(BUILD) ; patch -p1)
+	touch $@
+
+
+$(BUILD)/Makefile: $(BUILD)/.patched
+	cp config.site $(BUILD)/
+	( \
+		cd $(BUILD); \
+		CONFIG_SITE=./config.site READELF=true emconfigure ./configure --without-threads --without-pymalloc --disable-shared --disable-ipv6 --without-gcc --host=asmjs-unknown-emscripten --build=$(shell $(BUILD)/config.guess) --prefix=$(INSTALL) ; \
+	)
+
+
+$(BUILD)/$(LIB): $(BUILD)/Makefile $(HOSTPYTHON) $(HOSTPGEN) Setup.local
+	cp Setup.local $(BUILD)/Modules/
+	( \
+		cd $(BUILD)/Modules/zlib; \
+		emconfigure ./configure --static \
+	)
+	( \
+		cd $(BUILD); \
+		emmake make HOSTPYTHON=$(HOSTPYTHON) HOSTPGEN=$(HOSTPGEN) CROSS_COMPILE=yes $(LIB) \
+	)

--- a/3.6.4/Setup.local
+++ b/3.6.4/Setup.local
@@ -1,0 +1,30 @@
+# This file gets copied into the Modules/ folder when building
+# newlib configurations which do not support dynamic library
+# loading.
+
+*static*
+
+array arraymodule.c	# array objects
+cmath cmathmodule.c _math.c # -lm # complex math library functions
+math mathmodule.c _math.c # -lm # math library functions, e.g. sin()
+_struct _struct.c	# binary structure packing/unpacking
+time timemodule.c # -lm # time operations and variables
+_operator _operator.c	# operator.add() and similar goodies
+_random _randommodule.c	# Random number generator
+_collections _collectionsmodule.c # Container types
+_functools _functoolsmodule.c	# Tools for working with functions and callable objects
+itertools itertoolsmodule.c    # Functions creating iterators for efficient looping
+_bisect _bisectmodule.c	# Bisection algorithms
+
+_json _json.c
+
+binascii binascii.c
+
+zlib zlibmodule.c -IModules/zlib zlib/adler32.c zlib/crc32.c zlib/deflate.c zlib/infback.c zlib/inffast.c zlib/inflate.c zlib/inftrees.c zlib/trees.c zlib/zutil.c zlib/compress.c zlib/uncompr.c zlib/gzclose.c zlib/gzlib.c zlib/gzread.c zlib/gzwrite.c
+
+_sha1 sha1module.c
+_sha256 sha256module.c
+_sha512 sha512module.c
+_md5 md5module.c
+
+#future_builtins future_builtins.c

--- a/3.6.4/checksums
+++ b/3.6.4/checksums
@@ -1,0 +1,1 @@
+9de6494314ea199e3633211696735f65 ../downloads/Python-3.6.4.tgz

--- a/3.6.4/config.site
+++ b/3.6.4/config.site
@@ -1,0 +1,2 @@
+ac_cv_file__dev_ptmx=no
+ac_cv_file__dev_ptc=no

--- a/3.6.4/patches/add-emscripten-host.patch
+++ b/3.6.4/patches/add-emscripten-host.patch
@@ -1,0 +1,79 @@
+diff --git a/configure b/configure
+index 8cf777e..263719f 100755
+--- a/configure
++++ b/configure
+@@ -3202,6 +3202,9 @@ then
+ 	*-*-cygwin*)
+ 		ac_sys_system=Cygwin
+ 		;;
++	asmjs-*-*)
++		ac_sys_system=Emscripten
++		;;
+ 	*)
+ 		# for now, limit cross builds to known configurations
+ 		MACHDEP="unknown"
+@@ -3248,6 +3251,9 @@ if test "$cross_compiling" = yes; then
+ 	*-*-cygwin*)
+ 		_host_cpu=
+ 		;;
++	asmjs-*-*)
++		_host_cpu=
++		;;
+ 	*)
+ 		# for now, limit cross builds to known configurations
+ 		MACHDEP="unknown"
+diff --git a/configure.ac b/configure.ac
+index 78fe3c7..d7665b4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -322,6 +322,9 @@ then
+ 	*-*-cygwin*)
+ 		ac_sys_system=Cygwin
+ 		;;
++	asmjs-*-*)
++		ac_sys_system=Emscripten
++		;;
+ 	*)
+ 		# for now, limit cross builds to known configurations
+ 		MACHDEP="unknown"
+@@ -368,6 +371,9 @@ if test "$cross_compiling" = yes; then
+ 	*-*-cygwin*)
+ 		_host_cpu=
+ 		;;
++	asmjs-*-*)
++		_host_cpu=
++		;;
+ 	*)
+ 		# for now, limit cross builds to known configurations
+ 		MACHDEP="unknown"
+diff --git a/config.sub b/config.sub
+index d654d03..0d8236f 100755
+--- a/config.sub
++++ b/config.sub
+@@ -119,7 +119,8 @@ case $maybe_os in
+   linux-musl* | linux-uclibc* | uclinux-uclibc* | uclinux-gnu* | kfreebsd*-gnu* | \
+   knetbsd*-gnu* | netbsd*-gnu* | \
+   kopensolaris*-gnu* | cloudabi*-eabi* | \
+-  storm-chaos* | os2-emx* | rtmk-nova*)
++  storm-chaos* | os2-emx* | rtmk-nova* | \
++  emscripten)
+     os=-$maybe_os
+     basic_machine=`echo $1 | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/'`
+     ;;
+@@ -254,6 +255,7 @@ case $basic_machine in
+ 	| am33_2.0 \
+ 	| arc | arceb \
+ 	| arm | arm[bl]e | arme[lb] | armv[2-8] | armv[3-8][lb] | armv7[arm] \
++	| asmjs \
+ 	| avr | avr32 \
+ 	| be32 | be64 \
+ 	| bfin \
+@@ -1510,6 +1512,8 @@ case $os in
+ 	-dicos*)
+ 		os=-dicos
+ 		;;
++	-emscripten)
++		;;
+ 	-nacl*)
+ 		;;
+ 	-none)

--- a/3.6.4/patches/disable-set_inheritable.patch
+++ b/3.6.4/patches/disable-set_inheritable.patch
@@ -1,0 +1,24 @@
+*** a/Python/fileutils.c	2016-10-25 02:01:16.270148214 +0100
+--- b/Python/fileutils.c	2016-10-25 02:01:27.086148626 +0100
+***************
+*** 785,790 ****
+--- 785,793 ----
+  static int
+  set_inheritable(int fd, int inheritable, int raise, int *atomic_flag_works)
+  {
++ #ifdef EMSCRIPTEN
++     return 0;
++ #else
+  #ifdef MS_WINDOWS
+      HANDLE handle;
+      DWORD flags;
+***************
+*** 897,902 ****
+--- 900,906 ----
+      }
+      return 0;
+  #endif
++ #endif
+  }
+  
+  /* Make the file descriptor non-inheritable.


### PR DESCRIPTION
Not too many changes from 3.5, but there were a few.

Would you prefer this *replaces* the current 3.5.2 configuration (and then updates all the examples to use it) or adds to it (as this does).