### PR TITLE
Fix 06-cython-packages compilation

### DIFF
--- a/utils/patch_cython_module.py
+++ b/utils/patch_cython_module.py
@@ -8,7 +8,7 @@ def patch_init_name(src, module_path):
     new_name = '__'.join(module_path)
     dst = re.sub(
         r'(PyMODINIT_FUNC (?:init|PyInit_))' + re.escape(current_name),
-        '\\1' + re.escape(new_name),
+        '\\1' + new_name,
         src,
     )
     return dst


### PR DESCRIPTION
Previous version produced:
  PyMODINIT_FUNC PyInit_app\_\_b(void); /*proto*/
causing a compile-time error:
  gen1/app/b.c:790:26: error: expected ';' after top level declarator